### PR TITLE
changement image thumbnail pour logo + delete les logos jpg

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ enableEmoji   = true
   # Sets where "View More Posts" links
   viewMorePostLink     = "/blog/"
   # Sets default img for thumbnails
-  og_image             = "img/headers/hackathon-code-cover.JPG"
+  og_image             = "img/main/DotLayer_logo_short_COL_RVB.png"
 
 # Optional Params
   # Sets navbarTitle to match the section of the website


### PR DESCRIPTION
On avait une image du hackaton comme thumbnail. Est-ce que c'était on purpose?
Je sais pas trop comment vérifier si le nouveau fonctionne, j'avais remarqué sur le slack...

![snip1](https://user-images.githubusercontent.com/25728471/68360730-266bbc80-00ef-11ea-9214-b20f9e7ea7c4.PNG)
