### PR TITLE
Rss

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,8 +1,10 @@
 <!--
-  Rss is call in the <head> tag. It generates a link to dotlayer.org/index.xml which can be displayed as
-  simple xml text with the following warning: "This XML file does not appear to have any style information associated with it. 
-  The document tree is shown below." Don't worry, it's only the browser telling you it is showing you the raw data instead of
-  an html version. Only search engines will be accessing that file so the raw xml is all they are interested in.
+  This file is called in the header file inside the head tag. 
+  It generates a link to dotlayer.org/index.xml which can be displayed as raw data depending on your browser 
+  with the following warning: "This XML file does not appear to have any style information associated with it. 
+  The document tree is shown below." 
+  Don't worry, it's only the browser telling you it is showing you raw data. 
+  Only search engines will be accessing that file so the raw xml is all they are interested in.
 -->
 
 {{- $pctx := . -}}
@@ -24,7 +26,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
-    {{ with .Site.LanguageCode }}
+    {{ with .Site.Language.Lang }}
       <language>{{.}}</language>
     {{end}}
     <managingEditor>.Layer</managingEditor>
@@ -40,7 +42,6 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "02 Jan 2006" | safeHTML }}</pubDate>
-      {{ with .Site.Author.name }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,49 @@
+<!--
+  Rss is call in the <head> tag. It generates a link to dotlayer.org/index.xml which can be displayed as
+  simple xml text with the following warning: "This XML file does not appear to have any style information associated with it. 
+  The document tree is shown below." Don't worry, it's only the browser telling you it is showing you the raw data instead of
+  an html version. Only search engines will be accessing that file so the raw xml is all they are interested in.
+-->
+
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    {{ with .Site.LanguageCode }}
+      <language>{{.}}</language>
+    {{end}}
+    <managingEditor>.Layer</managingEditor>
+    <webMaster>.Layer</webMaster>
+    {{ if not .Date.IsZero }}
+      <lastBuildDate>{{ .Date.Format "02 Jan 2006" | safeHTML }}</lastBuildDate>
+    {{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+	    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "02 Jan 2006" | safeHTML }}</pubDate>
+      {{ with .Site.Author.name }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -7,18 +7,7 @@
   Only search engines will be accessing that file so the raw xml is all they are interested in.
 -->
 
-{{- $pctx := . -}}
-{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
-{{- $pages := slice -}}
-{{- if or $.IsHome $.IsSection -}}
-{{- $pages = $pctx.RegularPages -}}
-{{- else -}}
-{{- $pages = $pctx.Pages -}}
-{{- end -}}
-{{- $limit := .Site.Config.Services.RSS.Limit -}}
-{{- if ge $limit 1 -}}
-{{- $pages = $pages | first $limit -}}
-{{- end -}}
+
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
@@ -37,7 +26,7 @@
     {{ with .OutputFormats.Get "RSS" }}
 	    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range $pages }}
+    {{ range where (where .Site.Pages ".Section" "blog") "Kind" "page" }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,111 +5,116 @@
     Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html>
-    <head>
-        {{ partial "seo_schema" . }}
-        {{ with $.Scratch.Get "generalTitle" }}
+  <head>
+    {{ partial "seo_schema" . }}
+    {{ with $.Scratch.Get "generalTitle" }}
+        <title>{{ . }}</title>
+    {{ else }}
+        {{ with .Title }}
             <title>{{ . }}</title>
         {{ else }}
-            {{ with .Title }}
-                <title>{{ . }}</title>
-            {{ else }}
-                <title>{{ .Site.Title }}</title>
-            {{ end }}
+            <title>{{ .Site.Title }}</title>
         {{ end }}
+    {{ end }}
 
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        {{ partial "favicon" . }}
+    {{ partial "favicon" . }}
 
-        {{ with .Params.author }}
-            <meta name="author" content="{{ . }}">
-        {{ end }}
-        {{ with .Description }}
+    {{ with .Params.author }}
+        <meta name="author" content="{{ . }}">
+    {{ end }}
+    {{ with .Description }}
+        <meta name="description" content="{{ . }}">
+    {{ else }}
+        {{ with .Site.Params.description }}
             <meta name="description" content="{{ . }}">
-        {{ else }}
-            {{ with .Site.Params.description }}
-                <meta name="description" content="{{ . }}">
+        {{ end }}
+    {{ end }}
+
+    {{ if isset .Params "canonical" }}
+        {{ with .Params.canonical }}
+            <!-- NOTE: this rel="canonical" link is there for search engines
+            to not penalize duplicate content. If a post was taken from
+            another site and reuploaded here, then it's a good practice
+            to link to the canonical version of the post on the original
+            site to avoid duplicate content penality for optimizing the
+            sites for search engines. -->
+            <link rel="canonical" href="{{ . }}">
+        {{ end }}
+    {{ end }}
+
+    {{ template "_internal/twitter_cards.html" . }}
+    {{ template "_internal/opengraph.html" . }}
+    <!-- Facebook sharing -->
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+
+    {{ if .Params.featured }}
+    <meta property="og:image" content="{{.Site.BaseURL }}{{ .Params.featuredpath }}{{ .Params.featured }} "/>
+    {{ else }}
+        {{ with .Site.Params.og_image }}
+            <meta property="og:image" content="{{ . | relURL }}"/>
+            <meta property="og:image:secure_url" content="{{ . | absURL }}"/>
+        {{ end }}
+    {{ end }}
+
+    <!-- Twitter sharing -->
+    {{ if .Params.featured }}
+    <meta property="twitter:image" content="{{ .Site.BaseURL }}{{ .Params.featuredpath }}{{ .Params.featured }}"/>
+    {{ else }}
+        {{ with .Site.Params.og_image }}
+            <meta property="twitter:image" content="{{ . }}"/>
+        {{ end }}
+    {{ end }}
+
+    {{ template "_internal/schema.html" . }}
+    {{ template "_internal/google_news.html" . }}
+
+    {{ if isset .Site.Params "customcss" }}
+        {{ $.Scratch.Set "cssFiles" .Site.Params.customCSS }}
+    {{ else }}
+        {{ $.Scratch.Set "cssFiles" false }}
+    {{ end }}
+
+    <!-- If the value "default" is passed into the param then we will first
+          load the standard css files associated with the theme -->
+    {{ if or (in ($.Scratch.Get "cssFiles") "default") (eq ($.Scratch.Get "cssFiles") false) }}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-light.min.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,800,900|Source+Sans+Pro:400,700">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.1.25/jquery.fancybox.min.css">
+        <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
+        <link rel="stylesheet" href="{{ "css/add-on.css" | relURL }}">
+        <link rel="stylesheet" href="{{ "css/academicons.min.css" | relURL }}">
+    {{ end }}
+
+    <link rel="icon" href="{{ .Site.Params.faviconPath | absURL }}">
+
+    {{ if ne ($.Scratch.Get "cssFiles") false }}
+        {{ range $.Scratch.Get "cssFiles" }}
+            {{ if ne . "default" }}
+                <link rel="stylesheet" href="{{ . | relURL }}">
             {{ end }}
         {{ end }}
+    {{ end }}
 
-        {{ if isset .Params "canonical" }}
-            {{ with .Params.canonical }}
-                <!-- NOTE: this rel="canonical" link is there for search engines
-                to not penalize duplicate content. If a post was taken from
-                another site and reuploaded here, then it's a good practice
-                to link to the canonical version of the post on the original
-                site to avoid duplicate content penality for optimizing the
-                sites for search engines. -->
-                <link rel="canonical" href="{{ . }}">
-            {{ end }}
+    {{ if (not .Params.disable_highlight) }}
+        {{ $highTheme := .Site.Params.highlightjsTheme }}
+        {{ with .Site.Params.highlightjsVersion }}
+        <link href='{{ $.Site.Params.highlightjsCDN | default "//cdn.bootcss.com" }}/highlight.js/{{ . }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
         {{ end }}
+    {{ end }}
 
-        {{ template "_internal/twitter_cards.html" . }}
-        {{ template "_internal/opengraph.html" . }}
-        <!-- Facebook sharing -->
-        <meta property="og:image:width" content="512">
-        <meta property="og:image:height" content="512">
+    {{ range .AlternativeOutputFormats -}}
+        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
 
-        {{ if .Params.featured }}
-        <meta property="og:image" content="{{.Site.BaseURL }}{{ .Params.featuredpath }}{{ .Params.featured }} "/>
-        {{ else }}
-            {{ with .Site.Params.og_image }}
-                <meta property="og:image" content="{{ . | relURL }}"/>
-                <meta property="og:image:secure_url" content="{{ . | absURL }}"/>
-            {{ end }}
-        {{ end }}
+    {{ template "_internal/google_analytics.html" . }}
+  </head>
 
-        <!-- Twitter sharing -->
-        {{ if .Params.featured }}
-        <meta property="twitter:image" content="{{ .Site.BaseURL }}{{ .Params.featuredpath }}{{ .Params.featured }}"/>
-        {{ else }}
-            {{ with .Site.Params.og_image }}
-                <meta property="twitter:image" content="{{ . }}"/>
-            {{ end }}
-        {{ end }}
+  <body>
 
-        {{ template "_internal/schema.html" . }}
-        {{ template "_internal/google_news.html" . }}
-
-        {{ if isset .Site.Params "customcss" }}
-            {{ $.Scratch.Set "cssFiles" .Site.Params.customCSS }}
-        {{ else }}
-            {{ $.Scratch.Set "cssFiles" false }}
-        {{ end }}
-
-        <!-- If the value "default" is passed into the param then we will first
-             load the standard css files associated with the theme -->
-        {{ if or (in ($.Scratch.Get "cssFiles") "default") (eq ($.Scratch.Get "cssFiles") false) }}
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-light.min.css">
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,800,900|Source+Sans+Pro:400,700">
-            <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.1.25/jquery.fancybox.min.css">
-            <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
-            <link rel="stylesheet" href="{{ "css/add-on.css" | relURL }}">
-            <link rel="stylesheet" href="{{ "css/academicons.min.css" | relURL }}">
-        {{ end }}
-
-        <link rel="icon" href="{{ .Site.Params.faviconPath | absURL }}">
-
-        {{ if ne ($.Scratch.Get "cssFiles") false }}
-            {{ range $.Scratch.Get "cssFiles" }}
-                {{ if ne . "default" }}
-                    <link rel="stylesheet" href="{{ . | relURL }}">
-                {{ end }}
-            {{ end }}
-        {{ end }}
-
-{{ if (not .Params.disable_highlight) }}
-  {{ $highTheme := .Site.Params.highlightjsTheme }}
-    {{ with .Site.Params.highlightjsVersion }}
-    <link href='{{ $.Site.Params.highlightjsCDN | default "//cdn.bootcss.com" }}/highlight.js/{{ . }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
-  {{ end }}
-{{ end }}
-
-      {{ template "_internal/google_analytics.html" . }}
-    </head>
-    <body>
-
-      <!-- Wrapper -->
-      <div id="wrapper">
+  <!-- Wrapper -->
+  <div id="wrapper">


### PR DESCRIPTION
#79 

Le flux Rss fonctionnait depuis le debut dans le fond. 
L'affaire c'est juste que si on ouvre le lien direct dans le browser, on recoit un message qui dit "This XML file does not appear to have any style information associated with it. The document tree is shown below." qui veut juste dire que le browser affiche du raw data. 
On pourrait convertir le xml en html pour l'afficher plus beau, mais ca sert a rien vu que le Rss sert au search engines qui eux s'interessent juste au raw data anyway. 

Notre Rss ressemblerait a ca (avec le bon link au lieu de localhost haha..) 

![image](https://user-images.githubusercontent.com/24190818/86544866-81f97e80-bef8-11ea-9587-247ff8b156aa.png)

(J'ai essaye de mettre le nom de l'auteur de l'article, mais hugo a pas l'air de le permettre en ce moment... sad.)