### PR TITLE
Hide share-nav

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -24,11 +24,11 @@
 	
 	<nav class="main">
 		<ul>
-			{{ if $.Scratch.Get "shareNav" }}
+			<!-- {{ if $.Scratch.Get "shareNav" }}
 				<li id="share-nav" class="share-menu" style="display:none;">
 						<a class="fa-share-alt" href="#share-menu">Share</a>
 				</li>
-			{{ end }}
+			{{ end }} -->
 			
 			{{ if .Site.IsMultiLingual }}
 				{{ partial "language-switcher" . }}


### PR DESCRIPTION
Issue #119 

Le bouton share-nav fait rien. Je l'ai mis en commentaires. Je me rappel pu tant du comportement que ca avait, mais est-ce que c'etait pertinent de l'avoir?
On peut sharer les articles dans l'article anyway... 